### PR TITLE
Fix slow_write by including sleep function

### DIFF
--- a/ltext.lua
+++ b/ltext.lua
@@ -9,6 +9,13 @@ if not pcall(function()
 end) then
   inspect = false
 end
+local sleep
+sleep = function(seconds)
+  local time = os.clock()
+  while os.clock() - time <= seconds do
+    local _ = nil
+  end
+end
 local slow_write
 slow_write = function(text, rate)
   text = text and (tostring(text)) or ""
@@ -16,6 +23,7 @@ slow_write = function(text, rate)
   for n = 1, text:len() do
     os.sleep(rate)
     io.write(text:sub(n, n))
+    io.flush()
   end
 end
 local slow_print

--- a/ltext.moon
+++ b/ltext.moon
@@ -17,7 +17,7 @@ slow_write = (text, rate) ->
   text = text and (tostring text)   or ""
   rate = rate and 1/(tonumber rate) or 1/20
   for n=1, text\len!
-    os.sleep rate
+    sleep rate
     io.write text\sub n,n
     io.flush!
 

--- a/ltext.moon
+++ b/ltext.moon
@@ -9,12 +9,17 @@ if not pcall ->
     inspect    = require "inspect"
   inspect      = false
 
+sleep = (seconds) ->
+  time = os.clock!
+  while os.clock! - time <= seconds do nil
+
 slow_write = (text, rate) ->
   text = text and (tostring text)   or ""
   rate = rate and 1/(tonumber rate) or 1/20
   for n=1, text\len!
     os.sleep rate
     io.write text\sub n,n
+    io.flush!
 
 slow_print = (text, rate) ->
   slow_write text, rate


### PR DESCRIPTION
## Problem
slow_write used `os.sleep` which is not a function built into Lua.

Calling `slow_write("Hello World!", 12)` waited for 1 second before printing out all of the string at once. `io.write` calls did not print to the terminal because it was not being flushed until a newline.

## Solution
Added private `sleep(seconds)` function which uses `os.clock` to sleep for a number of seconds.
Added `io.flush!` call after each write.